### PR TITLE
Use `path.join()` instead of concatenation

### DIFF
--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -1,3 +1,5 @@
+var path = require('path');
+
 /**
  * route name for unifile api
  */
@@ -29,7 +31,7 @@ exports.staticFolders = [
   // assets
   {
     name: '/unifile-assets',
-    path: __dirname + '../../unifile-assets/'
+    path: path.join(__dirname, '/../../unifile-assets/')
   }
 ];
 /**
@@ -37,9 +39,9 @@ exports.staticFolders = [
  */
 exports.www =
 {
-  ROOT : __dirname + '/../www',
-  LOGIN_TEMPLATE_PATH: __dirname + '/templates/login-www.jade',
-  LOGIN_CSS_PATH: __dirname + '/templates/login.css',
+  ROOT : path.join(__dirname, '/../www'),
+  LOGIN_TEMPLATE_PATH: path.join(__dirname, '/templates/login-www.jade'),
+  LOGIN_CSS_PATH: path.join(__dirname, '/templates/login.css'),
   AUTH_FORM_ROUTE: '/api/v1.0/www-auth',
   AUTH_FORM_SUBMIT_ROUTE: '/api/v1.0/www-auth-submit',
   USERS: {
@@ -50,8 +52,8 @@ exports.www =
  */
 exports.ftp =
 {
-  LOGIN_TEMPLATE_PATH: __dirname + '/templates/login-ftp.jade',
-  LOGIN_CSS_PATH: __dirname + '/templates/login.css',
+  LOGIN_TEMPLATE_PATH: path.join(__dirname, '/templates/login-ftp.jade'),
+  LOGIN_CSS_PATH: path.join(__dirname, '/templates/login.css'),
   AUTH_FORM_ROUTE: '/api/v1.0/ftp-auth',
   AUTH_FORM_SUBMIT_ROUTE: '/api/v1.0/ftp-auth-submit'
 }
@@ -61,12 +63,12 @@ exports.ftp =
 exports.openPages =
 {
   ENABLED: false,
-  LOGIN_TEMPLATE_PATH: __dirname + '/templates/login-open-pages.jade',
-  LOGIN_CSS_PATH: __dirname + '/templates/login.css',
+  LOGIN_TEMPLATE_PATH: path.join(__dirname, '/templates/login-open-pages.jade'),
+  LOGIN_CSS_PATH: path.join(__dirname, '/templates/login.css'),
   AUTH_FORM_ROUTE: '/api/v1.0/open-pages-auth',
-  ROOT : __dirname + '/../open-pages',
+  ROOT : path.join(__dirname, '/../open-pages'),
   AUTH_FORM_SUBMIT_ROUTE: '/api/v1.0/open-pages-auth-submit',
-  SQLLITE_FILE: __dirname + '/../open-pages/db.sql',
+  SQLLITE_FILE: path.join(__dirname, '/../open-pages/db.sql'),
   OPEN_PAGES_WEB_ROUTE: '/op', // means that /op/{name}/ is serves the user's folder 'name'
 }
 /**


### PR DESCRIPTION
This will bring more compatibility system-wide and take care of missing `/` mistakes.

Close #29 