### PR TITLE
Deactivate GH service if no config

### DIFF
--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -88,9 +88,7 @@ exports.dropbox =
 exports.github = {
   LOGIN_TEMPLATE_PATH: path.join('/templates/login-ftp.jade'),
   LOGIN_CSS_PATH: path.join('/templates/login.css'),
-	AUTH_FORM_ROUTE: '/api/v1.0/github-auth',
-	client_id: 'b4e46028bf36d871f68d',
-	client_secret: 'c39806c4d0906cfeaac932012996a1919475cc78'
+	AUTH_FORM_ROUTE: '/api/v1.0/github/connect/oauth_callback'
 }
 
 /**

--- a/lib/services/github.js
+++ b/lib/services/github.js
@@ -384,7 +384,7 @@ exports.getInfo = function (request) {
 		display_name: 'GitHub',
 		image_small: 'unifile-assets/services/dropbox.png',
 		description: 'Edit html files from your GitHub repository.',
-		visible: true, // true if it should be listed in /v1.0/services/list/
+		visible: exports.config.hasOwnProperty('client_id'), // true if user set an app clientId
 		isLoggedIn: isConnected(request),
 		isConnected: isConnected(request),
 		isOAuth: true,

--- a/readme.md
+++ b/readme.md
@@ -145,6 +145,18 @@ Execute commands
     GET    /api/v1.0/dropbox/exec/put/path/to/file.txt:{string}      write data to a file
     POST    /api/v1.0/dropbox/exec/put/path/to/file.txt              write data to a file
 
+#Applications configuration
+
+Some services need an application registered on the plateform (GitHub, Dropbox...) to authorize Unifile. To activate them, you have to provide a `client_id` and a `client_secret` in the config object you pass to Unifile middleware. It have to be under the key namig the service:
+```
+{
+  github: {
+    "client_secret": SECRET_STRING,
+    "client_id": ID_STRING
+  }
+}
+```
+
 #License
 
 license: MIT


### PR DESCRIPTION
Remove github app credentials from the default config to force user to
use their own.

Add the documentation to do so in the README.