### PR TITLE
Fix batch check for Dropbox

### DIFF
--- a/lib/unifile-dropbox.js
+++ b/lib/unifile-dropbox.js
@@ -9,7 +9,7 @@ const Tools = require('unifile-common-tools');
 const NAME = 'dropbox';
 const DB_OAUTH_URL = 'https://www.dropbox.com/oauth2';
 
-/** ehehe
+/**
  * Make a call to the Dropbox API
  * @param {Object} session - Dropbox session storage
  * @param {string} path - End point path
@@ -103,10 +103,11 @@ function checkBatchEnd(session, result, checkRoute, jobId) {
 			newId = result.async_job_id;
 			// falls through
 		case 'in_progress':
+			newId = newId || jobId;
 			return callAPI(session, checkRoute, {
-				async_job_id: newId || jobId
+				async_job_id: newId
 			})
-			.then((result) => checkBatchEnd(session, result, checkRoute, jobId));
+			.then((result) => checkBatchEnd(session, result, checkRoute, newId));
 		case 'complete':
 			return Promise.resolve();
 	}


### PR DESCRIPTION
`async_job_id` was lost between recurrent call of the check function.

Closes #114