### PR TITLE
Encode non-ASCII chars in Dropbox headers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -69,7 +69,7 @@ rules:
   key-spacing: [2, {"mode": minimum}]
   keyword-spacing: [2, {"overrides": {"if":{"after": false}, "for":{"after": false}, "while":{"after": false}}}]
   linebreak-style: [2, unix]
-  max-len: [2, 120, 2]
+  max-len: [2, 120, 2, {"ignoreComments": true, "ignoreUrls": true}]
   new-parens: 2
   no-mixed-spaces-and-tabs: 2
   no-multiple-empty-lines: [2, {max: 2}]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - [Dropbox] Batch correctly overwrite existing files (https://github.com/silexlabs/unifile/issues/131)
 - [Dropbox] Batch now correctly rejects the promise if one action failed (https://github.com/silexlabs/unifile/issues/131)
 - [Dropbox] Batch upload uses `Buffer` for file content and supports UTF-8 (https://github.com/silexlabs/unifile/issues/130)
+- [Dropbox] All the methods support non-ASCII char in filename and content (https://github.com/silexlabs/unifile/issues/134)
 
 ## [2.0.0] - 2017-11-25
 ### Changed

--- a/lib/unifile-dropbox.js
+++ b/lib/unifile-dropbox.js
@@ -11,6 +11,8 @@ const {UnifileError, BatchError} = require('./error');
 const NAME = 'dropbox';
 const DB_OAUTH_URL = 'https://www.dropbox.com/oauth2';
 
+const charsToEncode = /[\u007f-\uffff]/g;
+
 /**
  * Make a call to the Dropbox API
  * @param {Object} session - Dropbox session storage
@@ -62,12 +64,18 @@ function callAPI(session, path, data, subdomain = 'api', isJson = true, headers 
 					errorMessage = (isJson ? body : JSON.parse(body)).error_summary;
 				}
 				// Dropbox only uses 409 for endpoints specific errors
+				let filename = null;
+				try {
+					filename = res.request.headers.hasOwnProperty('Dropbox-API-Arg') ?
+						JSON.parse(res.request.headers['Dropbox-API-Arg']).path
+						: JSON.parse(res.request.body).path;
+				} catch (e) {}
 				if(errorMessage.includes('/not_found/')) {
-					reject(new UnifileError(UnifileError.ENOENT, 'Not Found'));
+					reject(new UnifileError(UnifileError.ENOENT, `Not Found: ${filename}`));
 				} else if(errorMessage.startsWith('path/conflict/')) {
-					reject(new UnifileError(UnifileError.EINVAL, 'Creation failed due to conflict'));
+					reject(new UnifileError(UnifileError.EINVAL, `Creation failed due to conflict: ${filename}`));
 				} else if(errorMessage.startsWith('path/not_file/')) {
-					reject(new UnifileError(UnifileError.EINVAL, 'Path is a directory'));
+					reject(new UnifileError(UnifileError.EINVAL, `Path is a directory: ${filename}`));
 				} else if(res.statusCode === 401) {
 					reject(new UnifileError(UnifileError.EACCES, errorMessage));
 				} else {
@@ -141,6 +149,14 @@ function checkBatchEnd(session, result, checkRoute, jobId) {
 
 function makePathAbsolute(path) {
 	return path === '' ? path : '/' + path.split('/').filter((token) => token != '').join('/');
+}
+
+function safeStringify(v) {
+	return JSON.stringify(v).replace(charsToEncode,
+		function(c) {
+			return '\\u' + ('000' + c.charCodeAt(0).toString(16)).slice(-4);
+		}
+	);
 }
 
 /**
@@ -319,7 +335,7 @@ class DropboxConnector {
 		// TODO Handle file conflict and write mode
 		return callAPI(session, '/files/upload', data, 'content', false, {
 			'Content-Type': 'application/octet-stream',
-			'Dropbox-API-Arg': JSON.stringify({
+			'Dropbox-API-Arg': safeStringify({
 				path: makePathAbsolute(path),
 				mode: this.writeMode
 			})
@@ -352,7 +368,7 @@ class DropboxConnector {
 
 	readFile(session, path) {
 		return callAPI(session, '/files/download', {}, 'content', false, {
-			'Dropbox-API-Arg': JSON.stringify({
+			'Dropbox-API-Arg': safeStringify({
 				path: makePathAbsolute(path)
 			})
 		});
@@ -366,7 +382,7 @@ class DropboxConnector {
 			headers: {
 				'Authorization': 'Bearer ' + session.token,
 				'User-Agent': 'Unifile',
-				'Dropbox-API-Arg': JSON.stringify({
+				'Dropbox-API-Arg': safeStringify({
 					path: makePathAbsolute(path)
 				})
 			}

--- a/lib/unifile-dropbox.js
+++ b/lib/unifile-dropbox.js
@@ -151,6 +151,15 @@ function makePathAbsolute(path) {
 	return path === '' ? path : '/' + path.split('/').filter((token) => token != '').join('/');
 }
 
+/**
+ * Stringifies a JSON object and make it header-safe by encoding
+ * non-ASCII characters.
+ *
+ * @param {Object} v - JSON object to stringify
+ * @returns {String} the stringified object with special chars encoded
+ *
+ * @see https://www.dropboxforum.com/t5/API-support/HTTP-header-quot-Dropbox-API-Arg-quot-could-not-decode-input-as/td-p/173822
+ */
 function safeStringify(v) {
 	return JSON.stringify(v).replace(charsToEncode,
 		function(c) {

--- a/test/unifile-fs.js
+++ b/test/unifile-fs.js
@@ -23,7 +23,7 @@ function createDefaultConnector() {
 	return new FsConnector({sandbox: [Os.homedir(), Os.tmpdir()]});
 }
 
-describe.only('FsConnector', function() {
+describe('FsConnector', function() {
 	describe('constructor', function() {
 		it('create a new instance with empty config', function() {
 			const connector = new FsConnector();


### PR DESCRIPTION
Path with non-ASCII char are passed in header, creating an error.
Now we replace all special char with the \uXXXX encoding when stringifying the headers.

Closes #134